### PR TITLE
Fix: Ensure floating point division (Solves aliasing issue)

### DIFF
--- a/PolyBLEP.cpp
+++ b/PolyBLEP.cpp
@@ -54,10 +54,10 @@ inline double blep(double t, double dt) {
 inline double blamp(double t, double dt) {
     if (t < dt) {
         t = t / dt - 1;
-        return -1 / 3 * square_number(t) * t;
+        return -1 / 3.0 * square_number(t) * t;
     } else if (t > 1 - dt) {
         t = (t - 1) / dt + 1;
-        return 1 / 3 * square_number(t) * t;
+        return 1 / 3.0 * square_number(t) * t;
     } else {
         return 0;
     }


### PR DESCRIPTION
While validating the overtones of the TRI waveform I've noticed a lot of aliasing due to the incorrect integer division in blamp function, floating point division should be used.